### PR TITLE
feat: define shared convert API contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,10 @@ Bootstrap foundation for `officetomarkdown.com`.
 ## Notes
 
 - The `/api/convert` Python endpoint is a stub and intentionally returns `501` until conversion engine logic is implemented.
-- UploadThing integration and shared API contracts are planned in follow-up issues.
+- UploadThing integration is planned in a follow-up issue.
+- Shared conversion contracts live in `contracts/convert_contract.json` and are consumed by:
+  - `contracts/convert_contract.py` for Python runtime validation.
+  - `lib/contracts/convert.ts` for frontend/shared TypeScript types.
 
 ## Runtime boundaries
 
@@ -78,6 +81,33 @@ Bootstrap foundation for `officetomarkdown.com`.
 - Vercel body limit guardrail: request/response payloads must stay under 4.5 MB.
 - `api/convert.py` rejects byte-like fields (`fileBytes`, `fileBase64`, `fileData`, `fileContent`, `rawFile`) to enforce reference-only conversion requests.
 - `vercel.json` pins the Python endpoint max duration to `30s`.
+
+## Convert API contract
+
+POST `/api/convert` request fields:
+- `fileKey` (string)
+- `originalFilename` (string)
+- `sizeBytes` (non-negative integer)
+- `mimeType` (string)
+- `idempotencyKey` (string)
+
+POST `/api/convert` response fields:
+- `markdown` (string)
+- `inputFormat` (string)
+- `detectedFormat` (string)
+- `warnings` (string[])
+- `timings` (object with numeric values)
+- `errorCode` (`null` or one of the typed error codes)
+
+Typed `errorCode` categories:
+- `unsupported_format`
+- `missing_dependency`
+- `payload_too_large`
+- `conversion_failed`
+- `storage_read_failed`
+- `timeout`
+- `rate_limited`
+- `invalid_file`
 
 ## Preview verification
 

--- a/api/convert.py
+++ b/api/convert.py
@@ -11,20 +11,19 @@ from typing import Any
 
 from flask import Flask, Request, jsonify, request
 
-app = Flask(__name__)
-
-FORBIDDEN_BYTE_FIELDS = (
-    "fileBytes",
-    "fileBase64",
-    "fileData",
-    "fileContent",
-    "rawFile",
+from contracts.convert_contract import (
+    REQUEST_PROHIBITED_BYTE_FIELDS,
+    REQUEST_REQUIRED_FIELDS,
+    ConvertErrorCode,
+    is_convert_error_code,
 )
+
+app = Flask(__name__)
 
 
 @dataclass(slots=True)
 class ApiError:
-    errorCode: str
+    errorCode: ConvertErrorCode
     message: str
 
 
@@ -35,10 +34,13 @@ class ConvertResponse:
     detectedFormat: str
     warnings: list[str]
     timings: dict[str, int]
-    errorCode: str | None
+    errorCode: ConvertErrorCode | None
 
 
-def _json_error(error_code: str, message: str, status: HTTPStatus):
+def _json_error(error_code: ConvertErrorCode, message: str, status: HTTPStatus):
+    if not is_convert_error_code(error_code):
+        raise ValueError("Unexpected error code")
+
     payload = asdict(ApiError(errorCode=error_code, message=message))
     return jsonify(payload), status.value
 
@@ -53,10 +55,44 @@ def _extract_payload(incoming_request: Request) -> dict[str, Any]:
 
 
 def _validate_reference_only_payload(payload: dict[str, Any]) -> str | None:
-    forbidden_fields = [field for field in FORBIDDEN_BYTE_FIELDS if field in payload]
+    forbidden_fields = [
+        field for field in REQUEST_PROHIBITED_BYTE_FIELDS if field in payload
+    ]
     if forbidden_fields:
         fields = ", ".join(forbidden_fields)
         return f"Request payload must not include file bytes. Remove fields: {fields}"
+    return None
+
+
+def _validate_contract_payload(payload: dict[str, Any]) -> str | None:
+    missing_fields = [field for field in REQUEST_REQUIRED_FIELDS if field not in payload]
+    if missing_fields:
+        return f"Missing required field(s): {', '.join(missing_fields)}"
+
+    unexpected_fields = [field for field in payload if field not in REQUEST_REQUIRED_FIELDS]
+    if unexpected_fields:
+        return (
+            "Unexpected field(s): "
+            + ", ".join(unexpected_fields)
+            + ". Request must match the convert contract."
+        )
+
+    string_fields = ("fileKey", "originalFilename", "mimeType", "idempotencyKey")
+    invalid_strings = [
+        field
+        for field in string_fields
+        if not isinstance(payload.get(field), str) or not payload[field].strip()
+    ]
+    if invalid_strings:
+        return (
+            "Field(s) must be non-empty strings: "
+            + ", ".join(invalid_strings)
+        )
+
+    size_bytes = payload.get("sizeBytes")
+    if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes < 0:
+        return "Field sizeBytes must be a non-negative integer."
+
     return None
 
 
@@ -71,10 +107,10 @@ def convert_stub():
     if payload_error:
         return _json_error("invalid_file", payload_error, HTTPStatus.BAD_REQUEST)
 
-    file_key = payload.get("fileKey")
-    if not isinstance(file_key, str) or not file_key.strip():
+    contract_error = _validate_contract_payload(payload)
+    if contract_error:
         return _json_error(
-            "invalid_file", "Missing required field: fileKey", HTTPStatus.BAD_REQUEST
+            "invalid_file", contract_error, HTTPStatus.BAD_REQUEST
         )
 
     response = ConvertResponse(

--- a/contracts/__init__.py
+++ b/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Shared conversion contracts."""

--- a/contracts/convert_contract.json
+++ b/contracts/convert_contract.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "request": {
+    "requiredFields": [
+      "fileKey",
+      "originalFilename",
+      "sizeBytes",
+      "mimeType",
+      "idempotencyKey"
+    ],
+    "prohibitedByteFields": [
+      "fileBytes",
+      "fileBase64",
+      "fileData",
+      "fileContent",
+      "rawFile"
+    ]
+  },
+  "response": {
+    "requiredFields": [
+      "markdown",
+      "inputFormat",
+      "detectedFormat",
+      "warnings",
+      "timings",
+      "errorCode"
+    ]
+  },
+  "errorCodes": [
+    "unsupported_format",
+    "missing_dependency",
+    "payload_too_large",
+    "conversion_failed",
+    "storage_read_failed",
+    "timeout",
+    "rate_limited",
+    "invalid_file"
+  ]
+}

--- a/contracts/convert_contract.py
+++ b/contracts/convert_contract.py
@@ -1,0 +1,44 @@
+"""Canonical conversion API contract shared by UI and API code."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Final, Literal, TypeGuard, get_args
+
+ConvertErrorCode = Literal[
+    "unsupported_format",
+    "missing_dependency",
+    "payload_too_large",
+    "conversion_failed",
+    "storage_read_failed",
+    "timeout",
+    "rate_limited",
+    "invalid_file",
+]
+
+_CONTRACT_PATH = Path(__file__).with_name("convert_contract.json")
+_EXPECTED_ERROR_CODES: Final = set(get_args(ConvertErrorCode))
+
+
+@lru_cache(maxsize=1)
+def _load_contract() -> dict[str, Any]:
+    return json.loads(_CONTRACT_PATH.read_text(encoding="utf-8"))
+
+
+CONVERT_CONTRACT = _load_contract()
+REQUEST_REQUIRED_FIELDS = tuple(CONVERT_CONTRACT["request"]["requiredFields"])
+REQUEST_PROHIBITED_BYTE_FIELDS = tuple(CONVERT_CONTRACT["request"]["prohibitedByteFields"])
+RESPONSE_REQUIRED_FIELDS = tuple(CONVERT_CONTRACT["response"]["requiredFields"])
+CONVERT_ERROR_CODES = tuple(CONVERT_CONTRACT["errorCodes"])
+
+
+if set(CONVERT_ERROR_CODES) != _EXPECTED_ERROR_CODES:
+    raise RuntimeError(
+        "convert_contract.json errorCodes are out of sync with ConvertErrorCode."
+    )
+
+
+def is_convert_error_code(value: str) -> TypeGuard[ConvertErrorCode]:
+    return value in _EXPECTED_ERROR_CODES

--- a/lib/contracts/convert.ts
+++ b/lib/contracts/convert.ts
@@ -1,0 +1,74 @@
+import contract from "@/contracts/convert_contract.json";
+
+const EXPECTED_REQUEST_FIELDS = [
+  "fileKey",
+  "originalFilename",
+  "sizeBytes",
+  "mimeType",
+  "idempotencyKey",
+] as const;
+
+const EXPECTED_RESPONSE_FIELDS = [
+  "markdown",
+  "inputFormat",
+  "detectedFormat",
+  "warnings",
+  "timings",
+  "errorCode",
+] as const;
+
+const EXPECTED_ERROR_CODES = [
+  "unsupported_format",
+  "missing_dependency",
+  "payload_too_large",
+  "conversion_failed",
+  "storage_read_failed",
+  "timeout",
+  "rate_limited",
+  "invalid_file",
+] as const;
+
+export type ConvertRequestField = (typeof EXPECTED_REQUEST_FIELDS)[number];
+export type ConvertResponseField = (typeof EXPECTED_RESPONSE_FIELDS)[number];
+export type ConvertErrorCode = (typeof EXPECTED_ERROR_CODES)[number];
+
+export type ConvertRequest = {
+  fileKey: string;
+  originalFilename: string;
+  sizeBytes: number;
+  mimeType: string;
+  idempotencyKey: string;
+};
+
+export type ConvertResponse = {
+  markdown: string;
+  inputFormat: string;
+  detectedFormat: string;
+  warnings: string[];
+  timings: Record<string, number>;
+  errorCode: ConvertErrorCode | null;
+};
+
+function assertContractAlignment(): void {
+  const sameFields = (left: readonly string[], right: readonly string[]) =>
+    left.length === right.length && left.every((value, index) => value === right[index]);
+
+  if (!sameFields(EXPECTED_REQUEST_FIELDS, contract.request.requiredFields)) {
+    throw new Error("convert_contract.json request fields are out of sync");
+  }
+
+  if (!sameFields(EXPECTED_RESPONSE_FIELDS, contract.response.requiredFields)) {
+    throw new Error("convert_contract.json response fields are out of sync");
+  }
+
+  if (!sameFields(EXPECTED_ERROR_CODES, contract.errorCodes)) {
+    throw new Error("convert_contract.json error codes are out of sync");
+  }
+}
+
+assertContractAlignment();
+
+export const convertContract = contract;
+export const CONVERT_REQUEST_FIELDS = EXPECTED_REQUEST_FIELDS;
+export const CONVERT_RESPONSE_FIELDS = EXPECTED_RESPONSE_FIELDS;
+export const CONVERT_ERROR_CODES = EXPECTED_ERROR_CODES;

--- a/scripts/verify-preview-runtime.sh
+++ b/scripts/verify-preview-runtime.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 if [ "$#" -ne 1 ]; then
   echo "Usage: $0 <preview-url>"
-  echo "Example: $0 https://office-to-markdown-git-codex-issue-4-abc123-aslakhol.vercel.app"
+  echo "Example: $0 https://office-to-markdown-git-codex-issue-6-abc123-aslakhol.vercel.app"
   exit 1
 fi
 
@@ -45,7 +45,7 @@ echo "Checking payload boundary (no file bytes in request body) ..."
 boundary_status="$(curl -sS -o "$boundary_tmp" -w "%{http_code}" \
   -X POST "${preview_url}/api/convert" \
   -H "Content-Type: application/json" \
-  --data '{"fileKey":"uploads/example.docx","fileBase64":"ZmFrZQ=="}')"
+  --data '{"fileKey":"uploads/example.docx","originalFilename":"example.docx","sizeBytes":1234,"mimeType":"application/vnd.openxmlformats-officedocument.wordprocessingml.document","idempotencyKey":"preview-check-1","fileBase64":"ZmFrZQ=="}')"
 
 if [ "$boundary_status" != "400" ]; then
   echo "Boundary check failed: expected 400, got ${boundary_status}."
@@ -70,7 +70,7 @@ trap 'rm -f "$health_tmp" "$boundary_tmp" "$stub_tmp"' EXIT
 stub_status="$(curl -sS -o "$stub_tmp" -w "%{http_code}" \
   -X POST "${preview_url}/api/convert" \
   -H "Content-Type: application/json" \
-  --data '{"fileKey":"uploads/example.docx"}')"
+  --data '{"fileKey":"uploads/example.docx","originalFilename":"example.docx","sizeBytes":1234,"mimeType":"application/vnd.openxmlformats-officedocument.wordprocessingml.document","idempotencyKey":"preview-check-2"}')"
 
 if [ "$stub_status" != "501" ]; then
   echo "Stub check failed: expected 501, got ${stub_status}."

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,11 +1,19 @@
 import unittest
 
 from api.convert import app
+from contracts.convert_contract import CONVERT_ERROR_CODES, RESPONSE_REQUIRED_FIELDS
 
 
 class ConvertEndpointTests(unittest.TestCase):
     def setUp(self) -> None:
         self.client = app.test_client()
+        self.valid_request = {
+            "fileKey": "uploads/example.docx",
+            "originalFilename": "example.docx",
+            "sizeBytes": 1234,
+            "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "idempotencyKey": "req-12345",
+        }
 
     def test_healthcheck_returns_ok(self) -> None:
         response = self.client.get("/")
@@ -14,31 +22,70 @@ class ConvertEndpointTests(unittest.TestCase):
         self.assertEqual(response.json["status"], "ok")
         self.assertEqual(response.json["service"], "convert")
 
-    def test_missing_file_key_returns_validation_error(self) -> None:
-        response = self.client.post("/", json={})
+    def test_missing_required_fields_returns_validation_error(self) -> None:
+        payload = {
+            "fileKey": "uploads/example.docx",
+            "originalFilename": "example.docx",
+        }
+        response = self.client.post("/", json=payload)
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["errorCode"], "invalid_file")
-        self.assertIn("fileKey", response.json["message"])
+        self.assertIn("sizeBytes", response.json["message"])
+        self.assertIn("idempotencyKey", response.json["message"])
 
     def test_payload_with_file_bytes_is_rejected(self) -> None:
-        response = self.client.post(
-            "/",
-            json={"fileKey": "uploads/example.docx", "fileBase64": "ZmFrZQ=="},
-        )
+        payload = dict(self.valid_request)
+        payload["fileBase64"] = "ZmFrZQ=="
+        response = self.client.post("/", json=payload)
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json["errorCode"], "invalid_file")
         self.assertIn("must not include file bytes", response.json["message"])
         self.assertIn("fileBase64", response.json["message"])
 
-    def test_stub_returns_not_implemented_for_valid_payload(self) -> None:
-        response = self.client.post("/", json={"fileKey": "uploads/example.docx"})
+    def test_unexpected_fields_are_rejected(self) -> None:
+        payload = dict(self.valid_request)
+        payload["extraField"] = "not-allowed"
+        response = self.client.post("/", json=payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["errorCode"], "invalid_file")
+        self.assertIn("Unexpected field(s)", response.json["message"])
+        self.assertIn("extraField", response.json["message"])
+
+    def test_invalid_size_bytes_type_is_rejected(self) -> None:
+        payload = dict(self.valid_request)
+        payload["sizeBytes"] = "1234"
+        response = self.client.post("/", json=payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json["errorCode"], "invalid_file")
+        self.assertIn("sizeBytes", response.json["message"])
+
+    def test_stub_returns_not_implemented_for_valid_contract_payload(self) -> None:
+        response = self.client.post("/", json=self.valid_request)
 
         self.assertEqual(response.status_code, 501)
+        self.assertEqual(set(response.json.keys()), set(RESPONSE_REQUIRED_FIELDS))
         self.assertEqual(response.json["errorCode"], None)
         self.assertEqual(response.json["timings"], {"totalMs": 0})
         self.assertEqual(response.json["detectedFormat"], "unknown")
+
+    def test_error_codes_match_contract_categories(self) -> None:
+        self.assertEqual(
+            set(CONVERT_ERROR_CODES),
+            {
+                "unsupported_format",
+                "missing_dependency",
+                "payload_too_large",
+                "conversion_failed",
+                "storage_read_failed",
+                "timeout",
+                "rate_limited",
+                "invalid_file",
+            },
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a canonical convert contract (`contracts/convert_contract.json`) with required request/response fields and typed error codes
- enforce the full request contract in `api/convert.py` and keep error codes constrained to the approved set
- add frontend/shared TypeScript contract types aligned with the canonical contract
- expand Python tests for schema compliance and error code coverage
- update README contract documentation and preview verification payloads

## Testing
- `pnpm quality`

Closes #6
Refs #36
