### PR TITLE
feat: integrate UploadThing baseline upload flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,8 @@
 # App
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 
-# Upload and conversion flow (placeholders for upcoming issues)
+# UploadThing
 UPLOADTHING_TOKEN=
-UPLOADTHING_SECRET=
-UPLOADTHING_APP_ID=
 
 # Conversion runtime
 CONVERT_MAX_FILE_SIZE_MB=25

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Bootstrap foundation for `officetomarkdown.com`.
 ## Stack
 
 - Next.js (TypeScript) for product/UI.
+- UploadThing for signed browser uploads returning storage references.
 - Vercel Python function scaffold for conversion runtime.
 
 ## Prerequisites
@@ -57,6 +58,7 @@ Bootstrap foundation for `officetomarkdown.com`.
 ## Project layout
 
 - `app/`: Next.js App Router scaffold.
+- `app/api/uploadthing/`: UploadThing route handler and upload router.
 - `api/convert.py`: Python conversion endpoint stub.
 - `vercel.json`: Vercel function guardrails for Python runtime boundaries.
 - `.env.example`: environment variable template.
@@ -66,7 +68,7 @@ Bootstrap foundation for `officetomarkdown.com`.
 ## Notes
 
 - The `/api/convert` Python endpoint is a stub and intentionally returns `501` until conversion engine logic is implemented.
-- UploadThing integration is planned in a follow-up issue.
+- Upload UI uses UploadThing and sends only storage references (`fileKey`) + metadata to `/api/convert`.
 - Shared conversion contracts live in `contracts/convert_contract.json` and are consumed by:
   - `contracts/convert_contract.py` for Python runtime validation.
   - `lib/contracts/convert.ts` for frontend/shared TypeScript types.
@@ -76,11 +78,19 @@ Bootstrap foundation for `officetomarkdown.com`.
 | Route | Runtime | Source | Boundary |
 | --- | --- | --- | --- |
 | `/` and non-API pages | Next.js (App Router) | `app/` | UI/SEO only |
+| `/api/uploadthing` | Next.js Route Handler (Node.js) | `app/api/uploadthing/route.ts` | Signed upload orchestration, returns file references |
 | `/api/convert` | Vercel Python Function | `api/convert.py` | Accept file reference payloads only (no raw file bytes) |
 
 - Vercel body limit guardrail: request/response payloads must stay under 4.5 MB.
 - `api/convert.py` rejects byte-like fields (`fileBytes`, `fileBase64`, `fileData`, `fileContent`, `rawFile`) to enforce reference-only conversion requests.
 - `vercel.json` pins the Python endpoint max duration to `30s`.
+
+## Upload assumptions
+
+- UploadThing token is configured via `UPLOADTHING_TOKEN`.
+- Browser uploads are signed via `/api/uploadthing`; raw file bytes are sent directly to UploadThing storage.
+- UI and route middleware allow DOCX, PPTX, XLSX, and PDF uploads.
+- The upload route currently allows up to 32 MB (`blob` route config limit), while convert payload contract validation remains independent.
 
 ## Convert API contract
 

--- a/app/api/uploadthing/core.ts
+++ b/app/api/uploadthing/core.ts
@@ -1,0 +1,37 @@
+import { createUploadthing, type FileRouter } from "uploadthing/next";
+import { UploadThingError } from "uploadthing/server";
+
+import { isSupportedUploadFile } from "@/lib/upload/supported-formats";
+
+const f = createUploadthing();
+
+export const uploadRouter = {
+  officeDocument: f({
+    blob: {
+      maxFileCount: 1,
+      maxFileSize: "32MB",
+      minFileCount: 1,
+    },
+  })
+    .middleware(({ files }) => {
+      const invalidFiles = files.filter((file) => !isSupportedUploadFile(file.name, file.type));
+      if (invalidFiles.length > 0) {
+        const invalidNames = invalidFiles.map((file) => file.name).join(", ");
+        throw new UploadThingError({
+          code: "BAD_REQUEST",
+          message: `Unsupported file type for upload: ${invalidNames}`,
+        });
+      }
+
+      return {};
+    })
+    .onUploadComplete(({ file }) => ({
+      fileKey: file.key,
+      mimeType: file.type || "application/octet-stream",
+      originalFilename: file.name,
+      sizeBytes: file.size,
+      storageProvider: "uploadthing",
+    })),
+} satisfies FileRouter;
+
+export type UploadRouter = typeof uploadRouter;

--- a/app/api/uploadthing/route.ts
+++ b/app/api/uploadthing/route.ts
@@ -1,0 +1,9 @@
+import { createRouteHandler } from "uploadthing/next";
+
+import { uploadRouter } from "./core";
+
+export const runtime = "nodejs";
+
+export const { GET, POST } = createRouteHandler({
+  router: uploadRouter,
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,12 +7,81 @@
 }
 
 body {
+  background: #f5f7fb;
   margin: 0;
-  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   line-height: 1.5;
   padding: 2rem;
 }
 
 h1 {
   margin-top: 0;
+}
+
+.page-shell {
+  margin: 0 auto;
+  max-width: 52rem;
+}
+
+.panel {
+  background: #ffffff;
+  border: 1px solid #d8deea;
+  border-radius: 0.75rem;
+  margin-top: 1.5rem;
+  padding: 1.25rem;
+}
+
+.helper-text {
+  color: #4a5670;
+  margin-top: 0.25rem;
+}
+
+.upload-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.upload-form button {
+  background: #0f4c81;
+  border: none;
+  border-radius: 0.5rem;
+  color: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.55rem 0.9rem;
+  width: fit-content;
+}
+
+.upload-form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.error-text {
+  color: #b00020;
+  margin-bottom: 0;
+  margin-top: 1rem;
+}
+
+.result-block {
+  background: #f6f8fd;
+  border: 1px solid #d8deea;
+  border-radius: 0.5rem;
+  margin-top: 1rem;
+  padding: 0.75rem;
+}
+
+.result-block dl {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+}
+
+.result-block dt {
+  font-weight: 600;
+}
+
+.result-block dd {
+  margin: 0;
+  overflow-wrap: anywhere;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,11 @@
+import { UploadConvertPanel } from "@/components/upload-convert-panel";
+
 export default function HomePage() {
   return (
-    <main>
+    <main className="page-shell">
       <h1>office-to-markdown</h1>
-      <p>Foundation scaffold is running.</p>
+      <p>UploadThing baseline is wired and returns file references for conversion.</p>
+      <UploadConvertPanel />
     </main>
   );
 }

--- a/components/upload-convert-panel.tsx
+++ b/components/upload-convert-panel.tsx
@@ -84,7 +84,7 @@ export function UploadConvertPanel() {
 
     const uploadResult = await startUpload([selectedFile]);
     if (!uploadResult || uploadResult.length === 0) {
-      setUploadError("Upload did not return a file reference.");
+      setUploadError((currentMessage) => currentMessage ?? "Upload did not return a file reference.");
       return;
     }
 

--- a/components/upload-convert-panel.tsx
+++ b/components/upload-convert-panel.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+
+import type {
+  ConvertErrorCode,
+  ConvertRequest,
+  ConvertResponse,
+} from "@/lib/contracts/convert";
+import { isSupportedUploadFile, SUPPORTED_UPLOAD_FORMATS_LABEL } from "@/lib/upload/supported-formats";
+import { useUploadThing } from "@/lib/uploadthing";
+
+type UploadedReference = {
+  fileKey: string;
+  mimeType: string;
+  originalFilename: string;
+  sizeBytes: number;
+};
+
+type ConvertApiError = {
+  errorCode?: ConvertErrorCode;
+  message?: string;
+};
+
+const ACCEPTED_FILE_TYPES = [
+  ".docx",
+  ".pptx",
+  ".xlsx",
+  ".pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/pdf",
+].join(",");
+
+const EMPTY_MARKDOWN_MESSAGE = "Conversion API responded with empty markdown (expected while stub is active).";
+
+function makeIdempotencyKey(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `upload-${Date.now()}`;
+}
+
+export function UploadConvertPanel() {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [convertError, setConvertError] = useState<string | null>(null);
+  const [uploadedReference, setUploadedReference] = useState<UploadedReference | null>(null);
+  const [convertResponse, setConvertResponse] = useState<ConvertResponse | null>(null);
+  const [isConverting, setIsConverting] = useState(false);
+
+  const { isUploading, startUpload } = useUploadThing("officeDocument", {
+    onUploadError: (error) => {
+      setUploadError(error.message || "Upload failed.");
+    },
+  });
+
+  const isSubmitting = isUploading || isConverting;
+  const buttonLabel = useMemo(() => {
+    if (isUploading) {
+      return "Uploading...";
+    }
+    if (isConverting) {
+      return "Converting...";
+    }
+    return "Upload and send reference to convert API";
+  }, [isConverting, isUploading]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    setUploadError(null);
+    setConvertError(null);
+    setUploadedReference(null);
+    setConvertResponse(null);
+
+    if (!selectedFile) {
+      setUploadError("Select a file before submitting.");
+      return;
+    }
+
+    if (!isSupportedUploadFile(selectedFile.name, selectedFile.type)) {
+      setUploadError(`Unsupported file format. Supported formats: ${SUPPORTED_UPLOAD_FORMATS_LABEL}.`);
+      return;
+    }
+
+    const uploadResult = await startUpload([selectedFile]);
+    if (!uploadResult || uploadResult.length === 0) {
+      setUploadError("Upload did not return a file reference.");
+      return;
+    }
+
+    const uploadedFile = uploadResult[0];
+    const reference = uploadedFile.serverData;
+    if (!reference) {
+      setUploadError("Upload completed without server reference metadata.");
+      return;
+    }
+
+    const uploadedFileReference: UploadedReference = {
+      fileKey: reference.fileKey,
+      mimeType: reference.mimeType,
+      originalFilename: reference.originalFilename,
+      sizeBytes: reference.sizeBytes,
+    };
+    setUploadedReference(uploadedFileReference);
+
+    const convertPayload: ConvertRequest = {
+      fileKey: uploadedFileReference.fileKey,
+      idempotencyKey: makeIdempotencyKey(),
+      mimeType: uploadedFileReference.mimeType,
+      originalFilename: uploadedFileReference.originalFilename,
+      sizeBytes: uploadedFileReference.sizeBytes,
+    };
+
+    setIsConverting(true);
+    try {
+      const response = await fetch("/api/convert", {
+        body: JSON.stringify(convertPayload),
+        headers: { "Content-Type": "application/json" },
+        method: "POST",
+      });
+
+      const payload = (await response.json().catch(() => null)) as ConvertResponse | ConvertApiError | null;
+      if (!response.ok) {
+        if (response.status === 501) {
+          setConvertError("Upload succeeded. Convert endpoint is still a stub and returned HTTP 501.");
+          return;
+        }
+
+        const message =
+          payload && typeof payload === "object" && "message" in payload
+            ? payload.message
+            : `Conversion failed with status ${response.status}.`;
+        setConvertError(message || `Conversion failed with status ${response.status}.`);
+        return;
+      }
+
+      if (!payload || typeof payload !== "object" || !("markdown" in payload)) {
+        setConvertError("Conversion response did not match the expected contract.");
+        return;
+      }
+
+      setConvertResponse(payload as ConvertResponse);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unexpected conversion failure.";
+      setConvertError(message);
+    } finally {
+      setIsConverting(false);
+    }
+  }
+
+  return (
+    <section className="panel">
+      <h2>Prototype upload flow</h2>
+      <p className="helper-text">Supported formats: {SUPPORTED_UPLOAD_FORMATS_LABEL}</p>
+
+      <form className="upload-form" onSubmit={handleSubmit}>
+        <label htmlFor="office-file">Office file</label>
+        <input
+          accept={ACCEPTED_FILE_TYPES}
+          id="office-file"
+          name="office-file"
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0] ?? null;
+            setSelectedFile(file);
+            setUploadError(null);
+            setConvertError(null);
+          }}
+          type="file"
+        />
+        <button disabled={isSubmitting || !selectedFile} type="submit">
+          {buttonLabel}
+        </button>
+      </form>
+
+      {uploadError ? (
+        <p className="error-text" role="alert">
+          Upload error: {uploadError}
+        </p>
+      ) : null}
+
+      {uploadedReference ? (
+        <div className="result-block">
+          <h3>Uploaded reference</h3>
+          <dl>
+            <dt>fileKey</dt>
+            <dd>{uploadedReference.fileKey}</dd>
+            <dt>originalFilename</dt>
+            <dd>{uploadedReference.originalFilename}</dd>
+            <dt>mimeType</dt>
+            <dd>{uploadedReference.mimeType}</dd>
+            <dt>sizeBytes</dt>
+            <dd>{uploadedReference.sizeBytes}</dd>
+          </dl>
+        </div>
+      ) : null}
+
+      {convertError ? (
+        <p className="error-text" role="alert">
+          Convert error: {convertError}
+        </p>
+      ) : null}
+
+      {convertResponse ? (
+        <div className="result-block">
+          <h3>Convert response</h3>
+          <p>{convertResponse.markdown || EMPTY_MARKDOWN_MESSAGE}</p>
+          <p>detectedFormat: {convertResponse.detectedFormat}</p>
+          <p>inputFormat: {convertResponse.inputFormat}</p>
+          <p>warnings: {convertResponse.warnings.join(", ") || "none"}</p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/lib/upload/supported-formats.ts
+++ b/lib/upload/supported-formats.ts
@@ -1,0 +1,28 @@
+const SUPPORTED_UPLOAD_EXTENSIONS = new Set(["docx", "pptx", "xlsx", "pdf"]);
+
+const SUPPORTED_UPLOAD_MIME_TYPES = new Set([
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/pdf",
+]);
+
+export const SUPPORTED_UPLOAD_FORMATS_LABEL = "DOCX, PPTX, XLSX, PDF";
+
+function getFileExtension(fileName: string): string | null {
+  const lastDotIndex = fileName.lastIndexOf(".");
+  if (lastDotIndex === -1) {
+    return null;
+  }
+
+  return fileName.slice(lastDotIndex + 1).toLowerCase();
+}
+
+export function isSupportedUploadFile(fileName: string, mimeType: string): boolean {
+  const extension = getFileExtension(fileName);
+  if (extension && SUPPORTED_UPLOAD_EXTENSIONS.has(extension)) {
+    return true;
+  }
+
+  return SUPPORTED_UPLOAD_MIME_TYPES.has(mimeType.toLowerCase());
+}

--- a/lib/uploadthing.ts
+++ b/lib/uploadthing.ts
@@ -1,0 +1,5 @@
+import { generateReactHelpers } from "@uploadthing/react";
+
+import type { UploadRouter } from "@/app/api/uploadthing/core";
+
+export const { useUploadThing } = generateReactHelpers<UploadRouter>();

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
   },
   "packageManager": "pnpm@8.15.6",
   "dependencies": {
+    "@uploadthing/react": "^7.3.3",
     "next": "^15.2.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "uploadthing": "^7.7.4"
   },
   "devDependencies": {
     "@types/node": "^22.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@uploadthing/react':
+    specifier: ^7.3.3
+    version: 7.3.3(next@15.5.12)(react@19.2.4)(uploadthing@7.7.4)
   next:
     specifier: ^15.2.0
     version: 15.5.12(react-dom@19.2.4)(react@19.2.4)
@@ -14,6 +17,9 @@ dependencies:
   react-dom:
     specifier: ^19.0.0
     version: 19.2.4(react@19.2.4)
+  uploadthing:
+    specifier: ^7.7.4
+    version: 7.7.4(next@15.5.12)
 
 devDependencies:
   '@types/node':
@@ -36,6 +42,18 @@ devDependencies:
     version: 5.9.3
 
 packages:
+
+  /@effect/platform@0.90.3(effect@3.17.7):
+    resolution: {integrity: sha512-XvQ37yzWQKih4Du2CYladd1i/MzqtgkTPNCaN6Ku6No4CK83hDtXIV/rP03nEoBg2R3Pqgz6gGWmE2id2G81HA==}
+    peerDependencies:
+      effect: ^3.17.7
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.40.0
+      effect: 3.17.7
+      find-my-way-ts: 0.1.6
+      msgpackr: 1.11.8
+      multipasta: 0.2.7
+    dev: false
 
   /@emnapi/core@1.8.1:
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -393,6 +411,54 @@ packages:
     dev: false
     optional: true
 
+  /@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3:
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3:
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3:
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3:
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3:
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3:
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
     requiresBuild: true
@@ -511,6 +577,11 @@ packages:
     engines: {node: '>=12.4.0'}
     dev: true
 
+  /@opentelemetry/semantic-conventions@1.40.0:
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
@@ -518,6 +589,14 @@ packages:
   /@rushstack/eslint-patch@1.16.1:
     resolution: {integrity: sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==}
     dev: true
+
+  /@standard-schema/spec@1.0.0-beta.4:
+    resolution: {integrity: sha512-d3IxtzLo7P1oZ8s8YNvxzBUXRXojSut8pbPrTYtzsc5sn4+53jVqbk66pQerSZbZSJZQux6LkclB/+8IDordHg==}
+    dev: false
+
+  /@standard-schema/spec@1.1.0:
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+    dev: false
 
   /@swc/helpers@0.5.15:
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -858,6 +937,35 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@uploadthing/mime-types@0.3.6:
+    resolution: {integrity: sha512-t3tTzgwFV9+1D7lNDYc7Lr7kBwotHaX0ZsvoCGe7xGnXKo9z0jG2Sjl/msll12FeoLj77nyhsxevXyGpQDBvLg==}
+    dev: false
+
+  /@uploadthing/react@7.3.3(next@15.5.12)(react@19.2.4)(uploadthing@7.7.4):
+    resolution: {integrity: sha512-GhKbK42jL2Qs7OhRd2Z6j0zTLsnJTRJH31nR7RZnUYVoRh2aS/NabMAnHBNqfunIAGXVaA717Pvzq7vtxuPTmQ==}
+    peerDependencies:
+      next: '*'
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      uploadthing: ^7.2.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+    dependencies:
+      '@uploadthing/shared': 7.1.10
+      file-selector: 0.6.0
+      next: 15.5.12(react-dom@19.2.4)(react@19.2.4)
+      react: 19.2.4
+      uploadthing: 7.7.4(next@15.5.12)
+    dev: false
+
+  /@uploadthing/shared@7.1.10:
+    resolution: {integrity: sha512-R/XSA3SfCVnLIzFpXyGaKPfbwlYlWYSTuGjTFHuJhdAomuBuhopAHLh2Ois5fJibAHzi02uP1QCKbgTAdmArqg==}
+    dependencies:
+      '@uploadthing/mime-types': 0.3.6
+      effect: 3.17.7
+      sqids: 0.3.0
+    dev: false
 
   /acorn-jsx@5.3.2(acorn@8.16.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1218,6 +1326,13 @@ packages:
       es-errors: 1.3.0
       gopd: 1.2.0
     dev: true
+
+  /effect@3.17.7:
+    resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+    dev: false
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -1647,6 +1762,13 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      pure-rand: 6.1.0
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -1695,12 +1817,23 @@ packages:
       flat-cache: 4.0.1
     dev: true
 
+  /file-selector@0.6.0:
+    resolution: {integrity: sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==}
+    engines: {node: '>= 12'}
+    dependencies:
+      tslib: 2.8.1
+    dev: false
+
   /fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
     dev: true
+
+  /find-my-way-ts@0.1.6:
+    resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+    dev: false
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -2230,6 +2363,32 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
+  /msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    dev: false
+    optional: true
+
+  /msgpackr@1.11.8:
+    resolution: {integrity: sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==}
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+    dev: false
+
+  /multipasta@0.2.7:
+    resolution: {integrity: sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==}
+    dev: false
+
   /nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2298,6 +2457,15 @@ packages:
       object.entries: 1.1.9
       semver: 6.3.1
     dev: true
+
+  /node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      detect-libc: 2.1.2
+    dev: false
+    optional: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2466,6 +2634,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
     dev: true
+
+  /pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+    dev: false
 
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2724,6 +2896,10 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+    dev: false
+
   /stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
     dev: true
@@ -2976,6 +3152,35 @@ packages:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
     dev: true
+
+  /uploadthing@7.7.4(next@15.5.12):
+    resolution: {integrity: sha512-rlK/4JWHW5jP30syzWGBFDDXv3WJDdT8gn9OoxRJmXLoXi94hBmyyjxihGlNrKhBc81czyv8TkzMioe/OuKGfA==}
+    engines: {node: '>=18.13.0'}
+    peerDependencies:
+      express: '*'
+      fastify: '*'
+      h3: '*'
+      next: '*'
+      tailwindcss: ^3.0.0 || ^4.0.0-beta.0
+    peerDependenciesMeta:
+      express:
+        optional: true
+      fastify:
+        optional: true
+      h3:
+        optional: true
+      next:
+        optional: true
+      tailwindcss:
+        optional: true
+    dependencies:
+      '@effect/platform': 0.90.3(effect@3.17.7)
+      '@standard-schema/spec': 1.0.0-beta.4
+      '@uploadthing/mime-types': 0.3.6
+      '@uploadthing/shared': 7.1.10
+      effect: 3.17.7
+      next: 15.5.12(react-dom@19.2.4)(react@19.2.4)
+    dev: false
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}


### PR DESCRIPTION
## Summary
- add UploadThing server route and typed client helpers for signed browser uploads
- implement homepage upload panel that surfaces upload errors and posts only file references to /api/convert
- document UploadThing setup and signed upload assumptions in README/.env.example

## Validation
- pnpm quality
- pnpm build
- python3 -m py_compile api/convert.py

Closes #5
Refs #36