### PR TITLE
feat: build /prototype workbench

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,17 @@
 :root {
   color-scheme: light;
+  --paper: #f3efe7;
+  --ink: #1c120d;
+  --muted: #69574d;
+  --sand: #d9c5b2;
+  --tile: rgba(255, 250, 243, 0.92);
+  --accent: #b65f3b;
+  --accent-dark: #8e4526;
+  --panel-dark: #1f252c;
+  --panel-dark-border: #33404b;
+  --panel-dark-text: #f7f2eb;
+  --error: #9c1f0f;
+  --success: #2b6e4f;
 }
 
 * {
@@ -7,33 +19,117 @@
 }
 
 body {
-  background: #f5f7fb;
+  background:
+    radial-gradient(circle at top left, rgba(238, 201, 171, 0.72), transparent 28rem),
+    linear-gradient(180deg, #f7f2ea 0%, #efe7db 100%);
+  color: var(--ink);
   margin: 0;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  font-family: Georgia, "Times New Roman", serif;
   line-height: 1.5;
-  padding: 2rem;
+  min-height: 100vh;
+  padding: 2rem 1.25rem 3rem;
 }
 
 h1 {
-  margin-top: 0;
+  font-size: clamp(2.8rem, 7vw, 5rem);
+  line-height: 0.92;
+  margin: 0;
+}
+
+h2,
+h3,
+label,
+button,
+.eyebrow,
+.primary-link {
+  font-family: "Trebuchet MS", "Gill Sans", sans-serif;
 }
 
 .page-shell {
   margin: 0 auto;
-  max-width: 52rem;
+  max-width: 72rem;
+}
+
+.hero,
+.prototype-hero {
+  margin-bottom: 2rem;
+  max-width: 42rem;
+}
+
+.eyebrow {
+  color: var(--accent-dark);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+}
+
+.hero-copy {
+  color: var(--muted);
+  font-size: 1.1rem;
+  margin-top: 1rem;
+}
+
+.hero-actions {
+  margin-top: 1.5rem;
+}
+
+.primary-link,
+.upload-form button,
+.action-row button {
+  background: var(--accent);
+  border: none;
+  border-radius: 999px;
+  color: #fff8f1;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-weight: 700;
+  justify-content: center;
+  padding: 0.72rem 1.1rem;
+  text-decoration: none;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.primary-link:hover,
+.upload-form button:hover,
+.action-row button:hover {
+  background: var(--accent-dark);
+  transform: translateY(-1px);
 }
 
 .panel {
-  background: #ffffff;
-  border: 1px solid #d8deea;
-  border-radius: 0.75rem;
-  margin-top: 1.5rem;
-  padding: 1.25rem;
+  border-radius: 1.4rem;
+  padding: 1.4rem;
+}
+
+.panel-accent {
+  background: var(--tile);
+  border: 1px solid rgba(105, 87, 77, 0.18);
+  box-shadow: 0 20px 40px rgba(103, 80, 57, 0.1);
+}
+
+.panel-dark {
+  background: linear-gradient(180deg, #24303a, #1a2027);
+  border: 1px solid var(--panel-dark-border);
+  color: var(--panel-dark-text);
+  min-height: 100%;
+}
+
+.prototype-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .helper-text {
-  color: #4a5670;
+  color: var(--muted);
   margin-top: 0.25rem;
+}
+
+.helper-text-inverse {
+  color: rgba(247, 242, 235, 0.75);
 }
 
 .upload-form {
@@ -41,34 +137,39 @@ h1 {
   gap: 0.75rem;
 }
 
-.upload-form button {
-  background: #0f4c81;
-  border: none;
-  border-radius: 0.5rem;
-  color: #ffffff;
-  cursor: pointer;
+.upload-form input {
+  background: #fffdf9;
+  border: 1px solid var(--sand);
+  border-radius: 0.9rem;
+  color: var(--ink);
   font: inherit;
-  padding: 0.55rem 0.9rem;
+  padding: 0.85rem 1rem;
+}
+
+.upload-form button,
+.action-row button {
   width: fit-content;
 }
 
-.upload-form button:disabled {
+.upload-form button:disabled,
+.action-row button:disabled {
   cursor: not-allowed;
   opacity: 0.55;
+  transform: none;
 }
 
 .error-text {
-  color: #b00020;
+  color: var(--error);
   margin-bottom: 0;
   margin-top: 1rem;
 }
 
 .result-block {
-  background: #f6f8fd;
-  border: 1px solid #d8deea;
-  border-radius: 0.5rem;
+  background: rgba(247, 239, 231, 0.9);
+  border: 1px solid rgba(182, 95, 59, 0.2);
+  border-radius: 1rem;
   margin-top: 1rem;
-  padding: 0.75rem;
+  padding: 0.95rem;
 }
 
 .result-block dl {
@@ -84,4 +185,61 @@ h1 {
 .result-block dd {
   margin: 0;
   overflow-wrap: anywhere;
+}
+
+.result-header {
+  align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  justify-content: flex-end;
+}
+
+.markdown-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent),
+    rgba(11, 14, 18, 0.42);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1rem;
+  margin-top: 1rem;
+  min-height: 24rem;
+  padding: 1rem;
+}
+
+.markdown-card pre {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.status-text {
+  color: #a8efc8;
+  margin-bottom: 0;
+  margin-top: 0.9rem;
+}
+
+.result-meta {
+  color: rgba(247, 242, 235, 0.8);
+  margin-top: 1rem;
+}
+
+.result-meta p {
+  margin: 0.2rem 0;
+}
+
+@media (max-width: 860px) {
+  .prototype-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .result-header {
+    flex-direction: column;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,19 @@
-import { UploadConvertPanel } from "@/components/upload-convert-panel";
-
 export default function HomePage() {
   return (
     <main className="page-shell">
-      <h1>office-to-markdown</h1>
-      <p>UploadThing baseline is wired and returns file references for conversion.</p>
-      <UploadConvertPanel />
+      <section className="hero">
+        <p className="eyebrow">Prototype-first build</p>
+        <h1>office-to-markdown</h1>
+        <p className="hero-copy">
+          UploadThing and the shared convert contract are in place. The next milestone lives on the dedicated
+          prototype route.
+        </p>
+        <div className="hero-actions">
+          <a className="primary-link" href="/prototype">
+            Open /prototype
+          </a>
+        </div>
+      </section>
     </main>
   );
 }

--- a/app/prototype/page.tsx
+++ b/app/prototype/page.tsx
@@ -1,0 +1,17 @@
+import { UploadConvertPanel } from "@/components/upload-convert-panel";
+
+export default function PrototypePage() {
+  return (
+    <main className="page-shell">
+      <section className="prototype-hero">
+        <p className="eyebrow">Phase 1 / Issue #7</p>
+        <h1>/prototype</h1>
+        <p className="hero-copy">
+          Validate the upload to convert to markdown loop before product-shell work. This route stays intentionally
+          focused on the MVP formats and the raw conversion output.
+        </p>
+      </section>
+      <UploadConvertPanel />
+    </main>
+  );
+}

--- a/components/upload-convert-panel.tsx
+++ b/components/upload-convert-panel.tsx
@@ -39,12 +39,39 @@ function makeIdempotencyKey(): string {
   return globalThis.crypto?.randomUUID?.() ?? `upload-${Date.now()}`;
 }
 
+function buildPrototypeMarkdown(
+  reference: UploadedReference,
+  response: ConvertResponse | null,
+): string {
+  const markdown = response?.markdown ?? "";
+  if (markdown.trim()) {
+    return markdown;
+  }
+
+  const warnings = response?.warnings.length ? response.warnings.join(", ") : "none";
+
+  return [
+    "# Prototype Conversion Preview",
+    "",
+    `- Filename: ${reference.originalFilename}`,
+    `- Mime type: ${reference.mimeType}`,
+    `- Size bytes: ${reference.sizeBytes}`,
+    `- File key: ${reference.fileKey}`,
+    `- Detected format: ${response?.detectedFormat ?? "unknown"}`,
+    `- Warnings: ${warnings}`,
+    "",
+    "> The current backend stub returned no markdown. This placeholder keeps the",
+    "> prototype copy and download actions testable until the real converter lands.",
+  ].join("\n");
+}
+
 export function UploadConvertPanel() {
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [convertError, setConvertError] = useState<string | null>(null);
   const [uploadedReference, setUploadedReference] = useState<UploadedReference | null>(null);
   const [convertResponse, setConvertResponse] = useState<ConvertResponse | null>(null);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
   const [isConverting, setIsConverting] = useState(false);
 
   const { isUploading, startUpload } = useUploadThing("officeDocument", {
@@ -64,6 +91,14 @@ export function UploadConvertPanel() {
     return "Upload and send reference to convert API";
   }, [isConverting, isUploading]);
 
+  const renderedMarkdown = useMemo(() => {
+    if (!uploadedReference) {
+      return "";
+    }
+
+    return buildPrototypeMarkdown(uploadedReference, convertResponse);
+  }, [convertResponse, uploadedReference]);
+
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
@@ -71,6 +106,7 @@ export function UploadConvertPanel() {
     setConvertError(null);
     setUploadedReference(null);
     setConvertResponse(null);
+    setCopyStatus(null);
 
     if (!selectedFile) {
       setUploadError("Select a file before submitting.");
@@ -121,8 +157,8 @@ export function UploadConvertPanel() {
 
       const payload = (await response.json().catch(() => null)) as ConvertResponse | ConvertApiError | null;
       if (!response.ok) {
-        if (response.status === 501) {
-          setConvertError("Upload succeeded. Convert endpoint is still a stub and returned HTTP 501.");
+        if (response.status === 501 && payload && typeof payload === "object" && "markdown" in payload) {
+          setConvertResponse(payload as ConvertResponse);
           return;
         }
 
@@ -148,67 +184,125 @@ export function UploadConvertPanel() {
     }
   }
 
+  async function handleCopyMarkdown() {
+    if (!renderedMarkdown) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(renderedMarkdown);
+      setCopyStatus("Markdown copied.");
+    } catch {
+      setCopyStatus("Clipboard write failed.");
+    }
+  }
+
+  function handleDownloadMarkdown() {
+    if (!renderedMarkdown || !uploadedReference) {
+      return;
+    }
+
+    const blob = new Blob([renderedMarkdown], { type: "text/markdown;charset=utf-8" });
+    const fileBaseName = uploadedReference.originalFilename.replace(/\.[^.]+$/, "") || "conversion";
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${fileBaseName}.md`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
   return (
-    <section className="panel">
-      <h2>Prototype upload flow</h2>
-      <p className="helper-text">Supported formats: {SUPPORTED_UPLOAD_FORMATS_LABEL}</p>
-
-      <form className="upload-form" onSubmit={handleSubmit}>
-        <label htmlFor="office-file">Office file</label>
-        <input
-          accept={ACCEPTED_FILE_TYPES}
-          id="office-file"
-          name="office-file"
-          onChange={(event) => {
-            const file = event.currentTarget.files?.[0] ?? null;
-            setSelectedFile(file);
-            setUploadError(null);
-            setConvertError(null);
-          }}
-          type="file"
-        />
-        <button disabled={isSubmitting || !selectedFile} type="submit">
-          {buttonLabel}
-        </button>
-      </form>
-
-      {uploadError ? (
-        <p className="error-text" role="alert">
-          Upload error: {uploadError}
+    <section className="prototype-grid">
+      <div className="panel panel-accent">
+        <h2>Prototype upload flow</h2>
+        <p className="helper-text">
+          Upload a single document, forward only the file reference to the convert API, then preview the markdown
+          result.
         </p>
-      ) : null}
+        <p className="helper-text">Supported formats: {SUPPORTED_UPLOAD_FORMATS_LABEL}</p>
 
-      {uploadedReference ? (
-        <div className="result-block">
-          <h3>Uploaded reference</h3>
-          <dl>
-            <dt>fileKey</dt>
-            <dd>{uploadedReference.fileKey}</dd>
-            <dt>originalFilename</dt>
-            <dd>{uploadedReference.originalFilename}</dd>
-            <dt>mimeType</dt>
-            <dd>{uploadedReference.mimeType}</dd>
-            <dt>sizeBytes</dt>
-            <dd>{uploadedReference.sizeBytes}</dd>
-          </dl>
+        <form className="upload-form" onSubmit={handleSubmit}>
+          <label htmlFor="office-file">Office file</label>
+          <input
+            accept={ACCEPTED_FILE_TYPES}
+            id="office-file"
+            name="office-file"
+            onChange={(event) => {
+              const file = event.currentTarget.files?.[0] ?? null;
+              setSelectedFile(file);
+              setUploadError(null);
+              setConvertError(null);
+              setCopyStatus(null);
+            }}
+            type="file"
+          />
+          <button disabled={isSubmitting || !selectedFile} type="submit">
+            {buttonLabel}
+          </button>
+        </form>
+
+        {uploadError ? (
+          <p className="error-text" role="alert">
+            Upload error: {uploadError}
+          </p>
+        ) : null}
+
+        {convertError ? (
+          <p className="error-text" role="alert">
+            Convert error: {convertError}
+          </p>
+        ) : null}
+
+        {uploadedReference ? (
+          <div className="result-block">
+            <h3>Uploaded reference</h3>
+            <dl>
+              <dt>fileKey</dt>
+              <dd>{uploadedReference.fileKey}</dd>
+              <dt>originalFilename</dt>
+              <dd>{uploadedReference.originalFilename}</dd>
+              <dt>mimeType</dt>
+              <dd>{uploadedReference.mimeType}</dd>
+              <dt>sizeBytes</dt>
+              <dd>{uploadedReference.sizeBytes}</dd>
+            </dl>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="panel panel-dark">
+        <div className="result-header">
+          <div>
+            <h2>Markdown preview</h2>
+            <p className="helper-text helper-text-inverse">
+              {convertResponse?.markdown ? "Live response from convert API." : EMPTY_MARKDOWN_MESSAGE}
+            </p>
+          </div>
+          <div className="action-row">
+            <button disabled={!renderedMarkdown} onClick={handleCopyMarkdown} type="button">
+              Copy markdown
+            </button>
+            <button disabled={!renderedMarkdown} onClick={handleDownloadMarkdown} type="button">
+              Download .md
+            </button>
+          </div>
         </div>
-      ) : null}
 
-      {convertError ? (
-        <p className="error-text" role="alert">
-          Convert error: {convertError}
-        </p>
-      ) : null}
-
-      {convertResponse ? (
-        <div className="result-block">
-          <h3>Convert response</h3>
-          <p>{convertResponse.markdown || EMPTY_MARKDOWN_MESSAGE}</p>
-          <p>detectedFormat: {convertResponse.detectedFormat}</p>
-          <p>inputFormat: {convertResponse.inputFormat}</p>
-          <p>warnings: {convertResponse.warnings.join(", ") || "none"}</p>
+        <div className="markdown-card">
+          <pre>{renderedMarkdown || "Upload a supported file to generate a markdown preview."}</pre>
         </div>
-      ) : null}
+
+        {copyStatus ? <p className="status-text">{copyStatus}</p> : null}
+
+        {convertResponse ? (
+          <div className="result-meta">
+            <p>detectedFormat: {convertResponse.detectedFormat}</p>
+            <p>inputFormat: {convertResponse.inputFormat}</p>
+            <p>warnings: {convertResponse.warnings.join(", ") || "none"}</p>
+          </div>
+        ) : null}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add a dedicated `/prototype` route and landing-page entry point for the phase 1 prototype
- turn the upload panel into a two-column workbench with loading, error, copy, and markdown download actions
- treat the current `501` convert stub as a preview response so the prototype can render and exercise actions before the real converter lands

Closes #7

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`