### PR TITLE
feat: implement MarkItDown conversion endpoint

### DIFF
--- a/api/convert.py
+++ b/api/convert.py
@@ -1,13 +1,18 @@
-"""Stub conversion endpoint for Vercel Python runtime.
-
-This intentionally returns placeholder data until conversion logic is implemented.
-"""
+"""Conversion endpoint for Vercel Python runtime."""
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from functools import lru_cache
 from http import HTTPStatus
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from time import perf_counter
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import urlopen
 
 from flask import Flask, Request, jsonify, request
 
@@ -19,6 +24,14 @@ from contracts.convert_contract import (
 )
 
 app = Flask(__name__)
+
+SUPPORTED_FORMATS = {"docx", "pptx", "xlsx", "pdf"}
+SUPPORTED_MIME_TYPES = {
+    "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+}
 
 
 @dataclass(slots=True)
@@ -43,6 +56,10 @@ def _json_error(error_code: ConvertErrorCode, message: str, status: HTTPStatus):
 
     payload = asdict(ApiError(errorCode=error_code, message=message))
     return jsonify(payload), status.value
+
+
+def _timed_ms(start: float) -> int:
+    return int(round((perf_counter() - start) * 1000))
 
 
 def _extract_payload(incoming_request: Request) -> dict[str, Any]:
@@ -96,8 +113,91 @@ def _validate_contract_payload(payload: dict[str, Any]) -> str | None:
     return None
 
 
+def _get_max_file_size_bytes() -> int:
+    size_mb = int(os.getenv("CONVERT_MAX_FILE_SIZE_MB", "25"))
+    return size_mb * 1024 * 1024
+
+
+def _get_request_timeout_seconds() -> float:
+    timeout_ms = int(os.getenv("CONVERT_REQUEST_TIMEOUT_MS", "30000"))
+    return timeout_ms / 1000
+
+
+def _detect_input_format(payload: dict[str, Any]) -> str | None:
+    original_filename = str(payload["originalFilename"])
+    extension = Path(original_filename).suffix.lower().lstrip(".")
+    if extension in SUPPORTED_FORMATS:
+        return extension
+
+    mime_type = str(payload["mimeType"]).lower()
+    return SUPPORTED_MIME_TYPES.get(mime_type)
+
+
+def _resolve_uploadthing_url(file_key: str) -> str:
+    base_url = os.getenv("UPLOADTHING_FILE_URL_BASE", "https://utfs.io/f").rstrip("/")
+    return f"{base_url}/{quote(file_key, safe='')}"
+
+
+def _resolve_fixture_path(file_key: str) -> Path | None:
+    fixture_root = app.config.get("LOCAL_FIXTURE_ROOT")
+    if not fixture_root or not file_key.startswith("fixture://"):
+        return None
+
+    root = Path(fixture_root).resolve()
+    candidate = (root / file_key.removeprefix("fixture://")).resolve()
+    candidate.relative_to(root)
+    return candidate
+
+
+def _download_source_file(file_key: str, original_filename: str) -> tuple[Path, int]:
+    fixture_path = _resolve_fixture_path(file_key)
+    suffix = Path(original_filename).suffix or ""
+
+    if fixture_path is not None:
+        if not fixture_path.exists():
+            raise FileNotFoundError(f"Fixture not found for fileKey {file_key}.")
+
+        temporary_file = NamedTemporaryFile(delete=False, suffix=suffix)
+        try:
+            data = fixture_path.read_bytes()
+            temporary_file.write(data)
+            return Path(temporary_file.name), len(data)
+        finally:
+            temporary_file.close()
+
+    url = _resolve_uploadthing_url(file_key)
+    timeout_seconds = _get_request_timeout_seconds()
+
+    temporary_file = NamedTemporaryFile(delete=False, suffix=suffix)
+    try:
+        with urlopen(url, timeout=timeout_seconds) as response:
+            data = response.read()
+        temporary_file.write(data)
+        return Path(temporary_file.name), len(data)
+    finally:
+        temporary_file.close()
+
+
+@lru_cache(maxsize=1)
+def _get_markitdown_converter():
+    from markitdown import MarkItDown
+
+    return MarkItDown(enable_plugins=False)
+
+
+def _normalize_markdown(markdown: str) -> str:
+    return markdown.replace("\r\n", "\n").strip()
+
+
+def _convert_file(source_path: Path) -> str:
+    converter = _get_markitdown_converter()
+    result = converter.convert(str(source_path))
+    return _normalize_markdown(result.text_content)
+
+
 @app.post("/")
-def convert_stub():
+def convert_document():
+    request_started = perf_counter()
     try:
         payload = _extract_payload(request)
     except TypeError as exc:
@@ -113,15 +213,101 @@ def convert_stub():
             "invalid_file", contract_error, HTTPStatus.BAD_REQUEST
         )
 
-    response = ConvertResponse(
-        markdown="",
-        inputFormat="unknown",
-        detectedFormat="unknown",
-        warnings=["Conversion engine not implemented yet."],
-        timings={"totalMs": 0},
-        errorCode=None,
-    )
-    return jsonify(asdict(response)), HTTPStatus.NOT_IMPLEMENTED.value
+    input_format = _detect_input_format(payload)
+    if not input_format:
+        return _json_error(
+            "unsupported_format",
+            "Only DOCX, PPTX, XLSX, and PDF are supported in the MVP converter.",
+            HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+        )
+
+    if payload["sizeBytes"] > _get_max_file_size_bytes():
+        return _json_error(
+            "payload_too_large",
+            "File exceeds the configured conversion size limit.",
+            HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+        )
+
+    download_started = perf_counter()
+    source_path: Path | None = None
+    try:
+        source_path, downloaded_size = _download_source_file(
+            file_key=payload["fileKey"],
+            original_filename=payload["originalFilename"],
+        )
+        download_ms = _timed_ms(download_started)
+
+        if downloaded_size > _get_max_file_size_bytes():
+            return _json_error(
+                "payload_too_large",
+                "Downloaded file exceeds the configured conversion size limit.",
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            )
+
+        convert_started = perf_counter()
+        try:
+            markdown = _convert_file(source_path)
+        except RuntimeError as exc:
+            return _json_error(
+                "missing_dependency",
+                f"MarkItDown dependency error: {exc}",
+                HTTPStatus.SERVICE_UNAVAILABLE,
+            )
+        except Exception as exc:
+            return _json_error(
+                "conversion_failed",
+                f"MarkItDown conversion failed: {exc}",
+                HTTPStatus.UNPROCESSABLE_ENTITY,
+            )
+
+        warnings: list[str] = []
+        if not markdown:
+            warnings.append("MarkItDown returned empty markdown.")
+
+        response = ConvertResponse(
+            markdown=markdown,
+            inputFormat=input_format,
+            detectedFormat=input_format,
+            warnings=warnings,
+            timings={
+                "downloadMs": download_ms,
+                "convertMs": _timed_ms(convert_started),
+                "totalMs": _timed_ms(request_started),
+            },
+            errorCode=None,
+        )
+        return jsonify(asdict(response)), HTTPStatus.OK.value
+    except FileNotFoundError as exc:
+        return _json_error(
+            "storage_read_failed", str(exc), HTTPStatus.BAD_GATEWAY
+        )
+    except HTTPError as exc:
+        return _json_error(
+            "storage_read_failed",
+            f"Storage fetch failed with status {exc.code}.",
+            HTTPStatus.BAD_GATEWAY,
+        )
+    except TimeoutError:
+        return _json_error(
+            "timeout",
+            "Timed out while downloading the source file.",
+            HTTPStatus.GATEWAY_TIMEOUT,
+        )
+    except URLError as exc:
+        if isinstance(exc.reason, TimeoutError):
+            return _json_error(
+                "timeout",
+                "Timed out while downloading the source file.",
+                HTTPStatus.GATEWAY_TIMEOUT,
+            )
+        return _json_error(
+            "storage_read_failed",
+            f"Could not fetch source file: {exc.reason}",
+            HTTPStatus.BAD_GATEWAY,
+        )
+    finally:
+        if source_path is not None and source_path.exists():
+            source_path.unlink(missing_ok=True)
 
 
 @app.get("/")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
 flask==3.1.0
+markitdown[docx,pdf,pptx,xlsx]==0.1.5
+openpyxl==3.1.5
+python-docx==1.2.0
+python-pptx==1.0.2
+reportlab==4.4.10

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test helpers live in this package so unittest discovery can import them directly.

--- a/tests/fixture_factory.py
+++ b/tests/fixture_factory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from docx import Document
+from openpyxl import Workbook
+from pptx import Presentation
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+
+def build_sample_fixtures(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+
+    docx_path = root / "sample.docx"
+    document = Document()
+    document.add_heading("Sample DOCX", level=1)
+    document.add_paragraph("Hello from docx fixture.")
+    document.save(docx_path)
+
+    pptx_path = root / "sample.pptx"
+    presentation = Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[1])
+    slide.shapes.title.text = "Sample PPTX"
+    slide.placeholders[1].text = "Bullet one\nBullet two"
+    presentation.save(pptx_path)
+
+    xlsx_path = root / "sample.xlsx"
+    workbook = Workbook()
+    worksheet = workbook.active
+    worksheet.title = "Sheet1"
+    worksheet["A1"] = "Name"
+    worksheet["B1"] = "Score"
+    worksheet.append(["Alice", 42])
+    workbook.save(xlsx_path)
+
+    pdf_path = root / "sample.pdf"
+    pdf = canvas.Canvas(str(pdf_path), pagesize=letter)
+    pdf.drawString(72, 720, "Sample PDF")
+    pdf.drawString(72, 700, "Hello from pdf fixture.")
+    pdf.save()
+
+    (root / "broken.docx").write_bytes(bytes(range(256)))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,19 +1,36 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
 from api.convert import app
 from contracts.convert_contract import CONVERT_ERROR_CODES, RESPONSE_REQUIRED_FIELDS
+from tests.fixture_factory import build_sample_fixtures
 
 
 class ConvertEndpointTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.fixture_dir = TemporaryDirectory()
+        build_sample_fixtures(Path(cls.fixture_dir.name))
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.fixture_dir.cleanup()
+
     def setUp(self) -> None:
+        app.config["LOCAL_FIXTURE_ROOT"] = self.fixture_dir.name
         self.client = app.test_client()
         self.valid_request = {
-            "fileKey": "uploads/example.docx",
-            "originalFilename": "example.docx",
+            "fileKey": "fixture://sample.docx",
+            "originalFilename": "sample.docx",
             "sizeBytes": 1234,
             "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
             "idempotencyKey": "req-12345",
         }
+
+    def tearDown(self) -> None:
+        app.config.pop("LOCAL_FIXTURE_ROOT", None)
 
     def test_healthcheck_returns_ok(self) -> None:
         response = self.client.get("/")
@@ -24,8 +41,8 @@ class ConvertEndpointTests(unittest.TestCase):
 
     def test_missing_required_fields_returns_validation_error(self) -> None:
         payload = {
-            "fileKey": "uploads/example.docx",
-            "originalFilename": "example.docx",
+            "fileKey": "fixture://sample.docx",
+            "originalFilename": "sample.docx",
         }
         response = self.client.post("/", json=payload)
 
@@ -63,14 +80,97 @@ class ConvertEndpointTests(unittest.TestCase):
         self.assertEqual(response.json["errorCode"], "invalid_file")
         self.assertIn("sizeBytes", response.json["message"])
 
-    def test_stub_returns_not_implemented_for_valid_contract_payload(self) -> None:
-        response = self.client.post("/", json=self.valid_request)
+    def test_supported_fixture_formats_convert_successfully(self) -> None:
+        cases = [
+            (
+                "fixture://sample.docx",
+                "sample.docx",
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "Sample DOCX",
+                "docx",
+            ),
+            (
+                "fixture://sample.pptx",
+                "sample.pptx",
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                "Sample PPTX",
+                "pptx",
+            ),
+            (
+                "fixture://sample.xlsx",
+                "sample.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "Alice",
+                "xlsx",
+            ),
+            (
+                "fixture://sample.pdf",
+                "sample.pdf",
+                "application/pdf",
+                "Sample PDF",
+                "pdf",
+            ),
+        ]
 
-        self.assertEqual(response.status_code, 501)
-        self.assertEqual(set(response.json.keys()), set(RESPONSE_REQUIRED_FIELDS))
-        self.assertEqual(response.json["errorCode"], None)
-        self.assertEqual(response.json["timings"], {"totalMs": 0})
-        self.assertEqual(response.json["detectedFormat"], "unknown")
+        for file_key, original_filename, mime_type, expected_text, expected_format in cases:
+            with self.subTest(file_key=file_key):
+                response = self.client.post(
+                    "/",
+                    json={
+                        "fileKey": file_key,
+                        "originalFilename": original_filename,
+                        "sizeBytes": 2048,
+                        "mimeType": mime_type,
+                        "idempotencyKey": f"req-{expected_format}",
+                    },
+                )
+
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(set(response.json.keys()), set(RESPONSE_REQUIRED_FIELDS))
+                self.assertEqual(response.json["errorCode"], None)
+                self.assertEqual(response.json["inputFormat"], expected_format)
+                self.assertEqual(response.json["detectedFormat"], expected_format)
+                self.assertIn(expected_text, response.json["markdown"])
+                self.assertIn("downloadMs", response.json["timings"])
+                self.assertIn("convertMs", response.json["timings"])
+                self.assertIn("totalMs", response.json["timings"])
+
+    def test_missing_fixture_returns_storage_error(self) -> None:
+        payload = dict(self.valid_request)
+        payload["fileKey"] = "fixture://missing.docx"
+        payload["originalFilename"] = "missing.docx"
+        response = self.client.post("/", json=payload)
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json["errorCode"], "storage_read_failed")
+        self.assertIn("Fixture not found", response.json["message"])
+
+    def test_broken_docx_returns_conversion_failed(self) -> None:
+        payload = dict(self.valid_request)
+        payload["fileKey"] = "fixture://broken.docx"
+        payload["originalFilename"] = "broken.docx"
+        response = self.client.post("/", json=payload)
+
+        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.json["errorCode"], "conversion_failed")
+        self.assertIn("MarkItDown conversion failed", response.json["message"])
+
+    def test_unsupported_format_returns_typed_error(self) -> None:
+        payload = dict(self.valid_request)
+        payload["originalFilename"] = "sample.txt"
+        payload["mimeType"] = "text/plain"
+        response = self.client.post("/", json=payload)
+
+        self.assertEqual(response.status_code, 415)
+        self.assertEqual(response.json["errorCode"], "unsupported_format")
+
+    def test_missing_dependency_returns_typed_error(self) -> None:
+        with patch("api.convert._get_markitdown_converter", side_effect=RuntimeError("missing package")):
+            response = self.client.post("/", json=self.valid_request)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json["errorCode"], "missing_dependency")
+        self.assertIn("missing package", response.json["message"])
 
     def test_error_codes_match_contract_categories(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary
- replace the Python convert stub with real MarkItDown conversion for DOCX, PPTX, XLSX, and PDF
- fetch source files by reference, enforce typed format and size validation, and return normalized timings/error codes
- add Python integration coverage with fixture-backed success and failure cases for the MVP formats

Closes #8

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `python3 -m py_compile api/convert.py tests/test_convert.py tests/fixture_factory.py`