### PR TITLE
feat: wire prototype frontend to typed conversion states

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -234,6 +234,15 @@ button,
   margin: 0.2rem 0;
 }
 
+.warning-list {
+  margin: 0.35rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.warning-list li {
+  margin: 0.2rem 0;
+}
+
 @media (max-width: 860px) {
   .prototype-grid {
     grid-template-columns: 1fr;

--- a/components/upload-convert-panel-uploadthing.tsx
+++ b/components/upload-convert-panel-uploadthing.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { UploadConvertPanelBody, type UploadFileHandler } from "@/components/upload-convert-panel";
+import { useUploadThing } from "@/lib/uploadthing";
+
+export function UploadConvertPanelWithUploadThing() {
+  const { startUpload } = useUploadThing("officeDocument");
+
+  const uploadFile: UploadFileHandler = async (file) => {
+    const uploadResult = await startUpload([file]);
+    if (!uploadResult || uploadResult.length === 0) {
+      throw new Error("Upload did not return a file reference.");
+    }
+
+    const uploadedFile = uploadResult[0];
+    const reference = uploadedFile.serverData;
+    if (!reference) {
+      throw new Error("Upload completed without server reference metadata.");
+    }
+
+    return {
+      fileKey: reference.fileKey,
+      mimeType: reference.mimeType,
+      originalFilename: reference.originalFilename,
+      sizeBytes: reference.sizeBytes,
+    };
+  };
+
+  return <UploadConvertPanelBody uploadFile={uploadFile} />;
+}

--- a/components/upload-convert-panel.tsx
+++ b/components/upload-convert-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { FormEvent, useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import { FormEvent, useMemo, useReducer, useState } from "react";
 
 import type {
   ConvertErrorCode,
@@ -8,7 +9,6 @@ import type {
   ConvertResponse,
 } from "@/lib/contracts/convert";
 import { isSupportedUploadFile, SUPPORTED_UPLOAD_FORMATS_LABEL } from "@/lib/upload/supported-formats";
-import { useUploadThing } from "@/lib/uploadthing";
 
 type UploadedReference = {
   fileKey: string;
@@ -22,6 +22,25 @@ type ConvertApiError = {
   message?: string;
 };
 
+export type UploadFileHandler = (file: File) => Promise<UploadedReference>;
+
+type PrototypePhase = "idle" | "uploading" | "converting" | "succeeded" | "failed";
+
+type PrototypeState = {
+  convertResponse: ConvertResponse | null;
+  errorMessage: string | null;
+  phase: PrototypePhase;
+  selectedFile: File | null;
+  uploadedReference: UploadedReference | null;
+};
+
+type PrototypeAction =
+  | { type: "file-selected"; file: File | null }
+  | { type: "upload-started" }
+  | { type: "upload-succeeded"; reference: UploadedReference }
+  | { type: "convert-succeeded"; response: ConvertResponse }
+  | { type: "request-failed"; message: string };
+
 const ACCEPTED_FILE_TYPES = [
   ".docx",
   ".pptx",
@@ -34,9 +53,80 @@ const ACCEPTED_FILE_TYPES = [
 ].join(",");
 
 const EMPTY_MARKDOWN_MESSAGE = "Conversion API responded with empty markdown (expected while stub is active).";
+const MOCK_UPLOAD_DRIVER = "mock";
+const UploadConvertPanelWithUploadThing = dynamic(
+  () =>
+    import("./upload-convert-panel-uploadthing").then((module) => ({
+      default: module.UploadConvertPanelWithUploadThing,
+    })),
+  { ssr: false },
+);
+
+const CONVERT_ERROR_MESSAGES: Record<ConvertErrorCode, string> = {
+  unsupported_format: "This prototype only supports DOCX, PPTX, XLSX, and PDF files.",
+  missing_dependency: "The converter is missing a required server dependency.",
+  payload_too_large: "This file is too large for the current prototype limit.",
+  conversion_failed: "The converter could not extract markdown from this file.",
+  storage_read_failed: "The uploaded file could not be read back from storage.",
+  timeout: "The conversion took too long and timed out.",
+  rate_limited: "Too many conversion requests are in flight. Try again shortly.",
+  invalid_file: "The uploaded file metadata or request payload was invalid.",
+};
+
+const initialState: PrototypeState = {
+  convertResponse: null,
+  errorMessage: null,
+  phase: "idle",
+  selectedFile: null,
+  uploadedReference: null,
+};
 
 function makeIdempotencyKey(): string {
   return globalThis.crypto?.randomUUID?.() ?? `upload-${Date.now()}`;
+}
+
+function prototypeReducer(state: PrototypeState, action: PrototypeAction): PrototypeState {
+  switch (action.type) {
+    case "file-selected":
+      return {
+        convertResponse: null,
+        errorMessage: null,
+        phase: "idle",
+        selectedFile: action.file,
+        uploadedReference: null,
+      };
+    case "upload-started":
+      return {
+        ...state,
+        convertResponse: null,
+        errorMessage: null,
+        phase: "uploading",
+        uploadedReference: null,
+      };
+    case "upload-succeeded":
+      return {
+        ...state,
+        errorMessage: null,
+        phase: "converting",
+        uploadedReference: action.reference,
+      };
+    case "convert-succeeded":
+      return {
+        ...state,
+        convertResponse: action.response,
+        errorMessage: null,
+        phase: "succeeded",
+      };
+    case "request-failed":
+      return {
+        ...state,
+        convertResponse: null,
+        errorMessage: action.message,
+        phase: "failed",
+      };
+    default:
+      return state;
+  }
 }
 
 function buildPrototypeMarkdown(
@@ -65,90 +155,93 @@ function buildPrototypeMarkdown(
   ].join("\n");
 }
 
-export function UploadConvertPanel() {
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
-  const [uploadError, setUploadError] = useState<string | null>(null);
-  const [convertError, setConvertError] = useState<string | null>(null);
-  const [uploadedReference, setUploadedReference] = useState<UploadedReference | null>(null);
-  const [convertResponse, setConvertResponse] = useState<ConvertResponse | null>(null);
-  const [copyStatus, setCopyStatus] = useState<string | null>(null);
-  const [isConverting, setIsConverting] = useState(false);
+function getUserFacingConvertError(
+  payload: ConvertApiError | ConvertResponse | null,
+  status: number,
+): string {
+  if (payload && typeof payload === "object" && "errorCode" in payload && payload.errorCode) {
+    return CONVERT_ERROR_MESSAGES[payload.errorCode] ?? `Conversion failed with status ${status}.`;
+  }
 
-  const { isUploading, startUpload } = useUploadThing("officeDocument", {
-    onUploadError: (error) => {
-      setUploadError(error.message || "Upload failed.");
-    },
+  if (payload && typeof payload === "object" && "message" in payload && payload.message) {
+    return payload.message;
+  }
+
+  return `Conversion failed with status ${status}.`;
+}
+
+export function UploadConvertPanel() {
+  if (process.env.NEXT_PUBLIC_PROTOTYPE_UPLOAD_DRIVER === MOCK_UPLOAD_DRIVER) {
+    return <UploadConvertPanelMock />;
+  }
+
+  return <UploadConvertPanelWithUploadThing />;
+}
+
+function UploadConvertPanelMock() {
+  const uploadFile: UploadFileHandler = async (file) => ({
+    fileKey: `mock-${file.name.replace(/\s+/g, "-").toLowerCase()}`,
+    mimeType: file.type || "application/octet-stream",
+    originalFilename: file.name,
+    sizeBytes: file.size,
   });
 
-  const isSubmitting = isUploading || isConverting;
+  return <UploadConvertPanelBody uploadFile={uploadFile} />;
+}
+
+export function UploadConvertPanelBody({ uploadFile }: { uploadFile: UploadFileHandler }) {
+  const [state, dispatch] = useReducer(prototypeReducer, initialState);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+
+  const isSubmitting = state.phase === "uploading" || state.phase === "converting";
   const buttonLabel = useMemo(() => {
-    if (isUploading) {
+    if (state.phase === "uploading") {
       return "Uploading...";
     }
-    if (isConverting) {
+    if (state.phase === "converting") {
       return "Converting...";
     }
     return "Upload and send reference to convert API";
-  }, [isConverting, isUploading]);
+  }, [state.phase]);
 
   const renderedMarkdown = useMemo(() => {
-    if (!uploadedReference) {
+    if (!state.uploadedReference) {
       return "";
     }
 
-    return buildPrototypeMarkdown(uploadedReference, convertResponse);
-  }, [convertResponse, uploadedReference]);
+    return buildPrototypeMarkdown(state.uploadedReference, state.convertResponse);
+  }, [state.convertResponse, state.uploadedReference]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-
-    setUploadError(null);
-    setConvertError(null);
-    setUploadedReference(null);
-    setConvertResponse(null);
     setCopyStatus(null);
 
-    if (!selectedFile) {
-      setUploadError("Select a file before submitting.");
+    if (!state.selectedFile) {
+      dispatch({ type: "request-failed", message: "Select a file before submitting." });
       return;
     }
 
-    if (!isSupportedUploadFile(selectedFile.name, selectedFile.type)) {
-      setUploadError(`Unsupported file format. Supported formats: ${SUPPORTED_UPLOAD_FORMATS_LABEL}.`);
+    if (!isSupportedUploadFile(state.selectedFile.name, state.selectedFile.type)) {
+      dispatch({
+        type: "request-failed",
+        message: `Unsupported file format. Supported formats: ${SUPPORTED_UPLOAD_FORMATS_LABEL}.`,
+      });
       return;
     }
 
-    const uploadResult = await startUpload([selectedFile]);
-    if (!uploadResult || uploadResult.length === 0) {
-      setUploadError((currentMessage) => currentMessage ?? "Upload did not return a file reference.");
-      return;
-    }
-
-    const uploadedFile = uploadResult[0];
-    const reference = uploadedFile.serverData;
-    if (!reference) {
-      setUploadError("Upload completed without server reference metadata.");
-      return;
-    }
-
-    const uploadedFileReference: UploadedReference = {
-      fileKey: reference.fileKey,
-      mimeType: reference.mimeType,
-      originalFilename: reference.originalFilename,
-      sizeBytes: reference.sizeBytes,
-    };
-    setUploadedReference(uploadedFileReference);
-
-    const convertPayload: ConvertRequest = {
-      fileKey: uploadedFileReference.fileKey,
-      idempotencyKey: makeIdempotencyKey(),
-      mimeType: uploadedFileReference.mimeType,
-      originalFilename: uploadedFileReference.originalFilename,
-      sizeBytes: uploadedFileReference.sizeBytes,
-    };
-
-    setIsConverting(true);
+    dispatch({ type: "upload-started" });
     try {
+      const uploadedReference = await uploadFile(state.selectedFile);
+      dispatch({ type: "upload-succeeded", reference: uploadedReference });
+
+      const convertPayload: ConvertRequest = {
+        fileKey: uploadedReference.fileKey,
+        idempotencyKey: makeIdempotencyKey(),
+        mimeType: uploadedReference.mimeType,
+        originalFilename: uploadedReference.originalFilename,
+        sizeBytes: uploadedReference.sizeBytes,
+      };
+
       const response = await fetch("/api/convert", {
         body: JSON.stringify(convertPayload),
         headers: { "Content-Type": "application/json" },
@@ -158,29 +251,29 @@ export function UploadConvertPanel() {
       const payload = (await response.json().catch(() => null)) as ConvertResponse | ConvertApiError | null;
       if (!response.ok) {
         if (response.status === 501 && payload && typeof payload === "object" && "markdown" in payload) {
-          setConvertResponse(payload as ConvertResponse);
+          dispatch({ type: "convert-succeeded", response: payload as ConvertResponse });
           return;
         }
 
-        const message =
-          payload && typeof payload === "object" && "message" in payload
-            ? payload.message
-            : `Conversion failed with status ${response.status}.`;
-        setConvertError(message || `Conversion failed with status ${response.status}.`);
+        dispatch({
+          type: "request-failed",
+          message: getUserFacingConvertError(payload, response.status),
+        });
         return;
       }
 
       if (!payload || typeof payload !== "object" || !("markdown" in payload)) {
-        setConvertError("Conversion response did not match the expected contract.");
+        dispatch({
+          type: "request-failed",
+          message: "Conversion response did not match the expected contract.",
+        });
         return;
       }
 
-      setConvertResponse(payload as ConvertResponse);
+      dispatch({ type: "convert-succeeded", response: payload as ConvertResponse });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unexpected conversion failure.";
-      setConvertError(message);
-    } finally {
-      setIsConverting(false);
+      dispatch({ type: "request-failed", message });
     }
   }
 
@@ -198,12 +291,12 @@ export function UploadConvertPanel() {
   }
 
   function handleDownloadMarkdown() {
-    if (!renderedMarkdown || !uploadedReference) {
+    if (!renderedMarkdown || !state.uploadedReference) {
       return;
     }
 
     const blob = new Blob([renderedMarkdown], { type: "text/markdown;charset=utf-8" });
-    const fileBaseName = uploadedReference.originalFilename.replace(/\.[^.]+$/, "") || "conversion";
+    const fileBaseName = state.uploadedReference.originalFilename.replace(/\.[^.]+$/, "") || "conversion";
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");
     anchor.href = url;
@@ -230,42 +323,34 @@ export function UploadConvertPanel() {
             name="office-file"
             onChange={(event) => {
               const file = event.currentTarget.files?.[0] ?? null;
-              setSelectedFile(file);
-              setUploadError(null);
-              setConvertError(null);
+              dispatch({ type: "file-selected", file });
               setCopyStatus(null);
             }}
             type="file"
           />
-          <button disabled={isSubmitting || !selectedFile} type="submit">
+          <button disabled={isSubmitting || !state.selectedFile} type="submit">
             {buttonLabel}
           </button>
         </form>
 
-        {uploadError ? (
+        {state.errorMessage ? (
           <p className="error-text" role="alert">
-            Upload error: {uploadError}
+            Prototype error: {state.errorMessage}
           </p>
         ) : null}
 
-        {convertError ? (
-          <p className="error-text" role="alert">
-            Convert error: {convertError}
-          </p>
-        ) : null}
-
-        {uploadedReference ? (
+        {state.uploadedReference ? (
           <div className="result-block">
             <h3>Uploaded reference</h3>
             <dl>
               <dt>fileKey</dt>
-              <dd>{uploadedReference.fileKey}</dd>
+              <dd>{state.uploadedReference.fileKey}</dd>
               <dt>originalFilename</dt>
-              <dd>{uploadedReference.originalFilename}</dd>
+              <dd>{state.uploadedReference.originalFilename}</dd>
               <dt>mimeType</dt>
-              <dd>{uploadedReference.mimeType}</dd>
+              <dd>{state.uploadedReference.mimeType}</dd>
               <dt>sizeBytes</dt>
-              <dd>{uploadedReference.sizeBytes}</dd>
+              <dd>{state.uploadedReference.sizeBytes}</dd>
             </dl>
           </div>
         ) : null}
@@ -276,7 +361,7 @@ export function UploadConvertPanel() {
           <div>
             <h2>Markdown preview</h2>
             <p className="helper-text helper-text-inverse">
-              {convertResponse?.markdown ? "Live response from convert API." : EMPTY_MARKDOWN_MESSAGE}
+              {state.convertResponse?.markdown ? "Live response from convert API." : EMPTY_MARKDOWN_MESSAGE}
             </p>
           </div>
           <div className="action-row">
@@ -294,12 +379,27 @@ export function UploadConvertPanel() {
         </div>
 
         {copyStatus ? <p className="status-text">{copyStatus}</p> : null}
+        {!copyStatus && state.phase === "uploading" ? <p className="status-text">Uploading reference...</p> : null}
+        {!copyStatus && state.phase === "converting" ? <p className="status-text">Waiting for markdown...</p> : null}
 
-        {convertResponse ? (
+        {state.convertResponse ? (
           <div className="result-meta">
-            <p>detectedFormat: {convertResponse.detectedFormat}</p>
-            <p>inputFormat: {convertResponse.inputFormat}</p>
-            <p>warnings: {convertResponse.warnings.join(", ") || "none"}</p>
+            <p>detectedFormat: {state.convertResponse.detectedFormat}</p>
+            <p>inputFormat: {state.convertResponse.inputFormat}</p>
+            <p>
+              timings: download {state.convertResponse.timings.downloadMs ?? 0}ms / convert{" "}
+              {state.convertResponse.timings.convertMs ?? 0}ms / total {state.convertResponse.timings.totalMs ?? 0}ms
+            </p>
+            <p>warnings:</p>
+            {state.convertResponse.warnings.length > 0 ? (
+              <ul className="warning-list">
+                {state.convertResponse.warnings.map((warning) => (
+                  <li key={warning}>{warning}</li>
+                ))}
+              </ul>
+            ) : (
+              <p>none</p>
+            )}
           </div>
         ) : null}
       </div>

--- a/e2e/prototype.spec.ts
+++ b/e2e/prototype.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+
+const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+test("renders markdown and warnings after a successful conversion", async ({ page }) => {
+  let convertRequestBody: Record<string, unknown> | null = null;
+
+  await page.route("**/api/convert", async (route) => {
+    convertRequestBody = route.request().postDataJSON() as Record<string, unknown>;
+
+    await route.fulfill({
+      body: JSON.stringify({
+        detectedFormat: "docx",
+        errorCode: null,
+        inputFormat: "docx",
+        markdown: "# Converted heading\n\nBody copy from the browser smoke test.",
+        timings: { convertMs: 9, downloadMs: 4, totalMs: 13 },
+        warnings: ["OCR skipped for this fixture."],
+      }),
+      contentType: "application/json",
+      status: 200,
+    });
+  });
+
+  await page.goto("/prototype");
+  await page.getByLabel("Office file").setInputFiles({
+    mimeType: DOCX_MIME,
+    name: "browser-success.docx",
+    buffer: Buffer.from("fixture-docx"),
+  });
+  await page.getByRole("button", { name: "Upload and send reference to convert API" }).click();
+
+  await expect(page.locator(".markdown-card pre")).toContainText("Converted heading");
+  await expect(page.locator(".result-meta")).toContainText("OCR skipped for this fixture.");
+  await expect(page.locator(".result-block")).toContainText("browser-success.docx");
+
+  expect(convertRequestBody).not.toBeNull();
+  if (!convertRequestBody) {
+    throw new Error("Expected convert request body to be captured.");
+  }
+
+  const requestBody = convertRequestBody as {
+    fileKey: string;
+    idempotencyKey: string;
+    mimeType: string;
+    originalFilename: string;
+    sizeBytes: number;
+  };
+  expect(requestBody.fileKey).toBe("mock-browser-success.docx");
+  expect(requestBody.mimeType).toBe(DOCX_MIME);
+  expect(requestBody.originalFilename).toBe("browser-success.docx");
+  expect(requestBody.sizeBytes).toBe(12);
+  expect(typeof requestBody.idempotencyKey).toBe("string");
+});
+
+test("shows a validation error before upload for unsupported files", async ({ page }) => {
+  await page.goto("/prototype");
+  await page.getByLabel("Office file").setInputFiles({
+    mimeType: "text/plain",
+    name: "notes.txt",
+    buffer: Buffer.from("plain text"),
+  });
+  await page.getByRole("button", { name: "Upload and send reference to convert API" }).click();
+
+  await expect(page.locator("p[role='alert']")).toContainText("Unsupported file format");
+});
+
+test("maps typed conversion errors to user-facing copy", async ({ page }) => {
+  await page.route("**/api/convert", async (route) => {
+    await route.fulfill({
+      body: JSON.stringify({
+        errorCode: "conversion_failed",
+        message: "MarkItDown conversion failed: fixture exploded",
+      }),
+      contentType: "application/json",
+      status: 422,
+    });
+  });
+
+  await page.goto("/prototype");
+  await page.getByLabel("Office file").setInputFiles({
+    mimeType: DOCX_MIME,
+    name: "broken.docx",
+    buffer: Buffer.from("bad-fixture"),
+  });
+  await page.getByRole("button", { name: "Upload and send reference to convert API" }).click();
+
+  await expect(page.locator("p[role='alert']")).toContainText(
+    "The converter could not extract markdown from this file.",
+  );
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test:browser": "playwright test",
     "test": "./scripts/run-python-tests.sh",
     "quality": "pnpm lint && pnpm typecheck && pnpm test"
   },
@@ -20,6 +21,7 @@
     "uploadthing": "^7.7.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@types/node": "^22.12.0",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  use: {
+    baseURL: "http://127.0.0.1:3100",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "NEXT_PUBLIC_PROTOTYPE_UPLOAD_DRIVER=mock pnpm exec next dev -p 3100",
+    port: 3100,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ dependencies:
     version: 7.3.3(next@15.5.12)(react@19.2.4)(uploadthing@7.7.4)
   next:
     specifier: ^15.2.0
-    version: 15.5.12(react-dom@19.2.4)(react@19.2.4)
+    version: 15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
   react:
     specifier: ^19.0.0
     version: 19.2.4
@@ -22,6 +22,9 @@ dependencies:
     version: 7.7.4(next@15.5.12)
 
 devDependencies:
+  '@playwright/test':
+    specifier: ^1.58.2
+    version: 1.58.2
   '@types/node':
     specifier: ^22.12.0
     version: 22.19.13
@@ -582,6 +585,13 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
+  /@playwright/test@1.58.2:
+    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright: 1.58.2
+
   /@rtsao/scc@1.1.0:
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
     dev: true
@@ -954,7 +964,7 @@ packages:
     dependencies:
       '@uploadthing/shared': 7.1.10
       file-selector: 0.6.0
-      next: 15.5.12(react-dom@19.2.4)(react@19.2.4)
+      next: 15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
       react: 19.2.4
       uploadthing: 7.7.4(next@15.5.12)
     dev: false
@@ -1862,6 +1872,13 @@ packages:
       is-callable: 1.2.7
     dev: true
 
+  /fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
     dev: true
@@ -2405,7 +2422,7 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next@15.5.12(react-dom@19.2.4)(react@19.2.4):
+  /next@15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4):
     resolution: {integrity: sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -2427,6 +2444,7 @@ packages:
         optional: true
     dependencies:
       '@next/env': 15.5.12
+      '@playwright/test': 1.58.2
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001776
       postcss: 8.4.31
@@ -2602,6 +2620,20 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
     dev: true
+
+  /playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  /playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
 
   /possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3179,7 +3211,7 @@ packages:
       '@uploadthing/mime-types': 0.3.6
       '@uploadthing/shared': 7.1.10
       effect: 3.17.7
-      next: 15.5.12(react-dom@19.2.4)(react@19.2.4)
+      next: 15.5.12(@playwright/test@1.58.2)(react-dom@19.2.4)(react@19.2.4)
     dev: false
 
   /uri-js@4.4.1:


### PR DESCRIPTION
## Summary
- move the prototype workbench onto a reducer-driven state flow with deterministic upload, convert, success, and failure transitions
- add typed user-facing convert error mapping, warning rendering, and a mock upload driver for browser-side validation
- add Playwright browser coverage for success, validation, and typed conversion failure states on `/prototype`

Closes #9

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test:browser`